### PR TITLE
fix dependency injection errors in di:compile

### DIFF
--- a/Controller/Adminhtml/Slider.php
+++ b/Controller/Adminhtml/Slider.php
@@ -43,19 +43,17 @@ abstract class Slider extends \Magento\Backend\App\Action
      * 
      * @param \Mageplaza\Productslider\Model\SliderFactory $sliderFactory
      * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory
      * @param \Magento\Backend\App\Action\Context $context
      */
     public function __construct(
         \Mageplaza\Productslider\Model\SliderFactory $sliderFactory,
         \Magento\Framework\Registry $coreRegistry,
-        \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory,
         \Magento\Backend\App\Action\Context $context
     )
     {
         $this->_sliderFactory         = $sliderFactory;
         $this->_coreRegistry          = $coreRegistry;
-        $this->_resultRedirectFactory = $resultRedirectFactory;
+        $this->_resultRedirectFactory = $context->getResultRedirectFactory();
         parent::__construct($context);
     }
 

--- a/Controller/Adminhtml/Slider/Edit.php
+++ b/Controller/Adminhtml/Slider/Edit.php
@@ -41,28 +41,24 @@ class Edit extends \Mageplaza\Productslider\Controller\Adminhtml\Slider
     /**
      * constructor
      * 
-     * @param \Magento\Backend\Model\Session $backendSession
      * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
      * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
      * @param \Mageplaza\Productslider\Model\SliderFactory $sliderFactory
      * @param \Magento\Framework\Registry $registry
-     * @param \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory
      * @param \Magento\Backend\App\Action\Context $context
      */
     public function __construct(
-        \Magento\Backend\Model\Session $backendSession,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
         \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
         \Mageplaza\Productslider\Model\SliderFactory $sliderFactory,
         \Magento\Framework\Registry $registry,
-        \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory,
         \Magento\Backend\App\Action\Context $context
     )
     {
-        $this->_backendSession    = $backendSession;
+        $this->_backendSession    = $context->getSession();
         $this->_resultPageFactory = $resultPageFactory;
         $this->_resultJsonFactory = $resultJsonFactory;
-        parent::__construct($sliderFactory, $registry, $resultRedirectFactory, $context);
+        parent::__construct($sliderFactory, $registry, $context);
     }
 
     /**

--- a/Controller/Adminhtml/Slider/Save.php
+++ b/Controller/Adminhtml/Slider/Save.php
@@ -34,7 +34,6 @@ class Save extends \Mageplaza\Productslider\Controller\Adminhtml\Slider
     /**
      * constructor
      * 
-     * @param \Magento\Backend\Model\Session $backendSession
      * @param \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter
      * @param \Mageplaza\Productslider\Model\SliderFactory $sliderFactory
      * @param \Magento\Framework\Registry $registry
@@ -42,7 +41,6 @@ class Save extends \Mageplaza\Productslider\Controller\Adminhtml\Slider
      * @param \Magento\Backend\App\Action\Context $context
      */
     public function __construct(
-        \Magento\Backend\Model\Session $backendSession,
         \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
         \Mageplaza\Productslider\Model\SliderFactory $sliderFactory,
         \Magento\Framework\Registry $registry,
@@ -50,7 +48,7 @@ class Save extends \Mageplaza\Productslider\Controller\Adminhtml\Slider
         \Magento\Backend\App\Action\Context $context
     )
     {
-        $this->_backendSession = $backendSession;
+        $this->_backendSession = $context->getSession();
         $this->_dateFilter     = $dateFilter;
         parent::__construct($sliderFactory, $registry, $resultRedirectFactory, $context);
     }

--- a/Controller/Adminhtml/Slider/Save.php
+++ b/Controller/Adminhtml/Slider/Save.php
@@ -50,7 +50,7 @@ class Save extends \Mageplaza\Productslider\Controller\Adminhtml\Slider
     {
         $this->_backendSession = $context->getSession();
         $this->_dateFilter     = $dateFilter;
-        parent::__construct($sliderFactory, $registry, $resultRedirectFactory, $context);
+        parent::__construct($sliderFactory, $registry, $context);
     }
 
     /**

--- a/Controller/Adminhtml/Slider/Save.php
+++ b/Controller/Adminhtml/Slider/Save.php
@@ -37,14 +37,12 @@ class Save extends \Mageplaza\Productslider\Controller\Adminhtml\Slider
      * @param \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter
      * @param \Mageplaza\Productslider\Model\SliderFactory $sliderFactory
      * @param \Magento\Framework\Registry $registry
-     * @param \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory
      * @param \Magento\Backend\App\Action\Context $context
      */
     public function __construct(
         \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
         \Mageplaza\Productslider\Model\SliderFactory $sliderFactory,
         \Magento\Framework\Registry $registry,
-        \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory,
         \Magento\Backend\App\Action\Context $context
     )
     {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -116,7 +116,6 @@ class Data extends CoreHelper
 		Escaper $escaper,
 		StoreManagerInterface $storeManager,
 		ObjectManagerInterface $objectManager,
-		LoggerInterface $logger,
 		\Magento\Framework\Pricing\Helper\Data $priceHelper
 	)
 	{
@@ -125,7 +124,7 @@ class Data extends CoreHelper
 		$this->_queryFactory = $queryFactory;
 		$this->_escaper      = $escaper;
 		$this->_storeManager = $storeManager;
-		$this->logger        = $logger;
+		$this->logger        = $context->getLogger();
 		$this->_priceHelper  = $priceHelper;
 		$this->objectManager   = $objectManager;
 


### PR DESCRIPTION
### Description
When using this plugin stage 6 of the Dependency Injection compile command throws errors due to the injected options already being present in the context. This update removes those errors.

### Manual testing scenarios
1. install this package
2. run bin/magento cache:clean
3. run bin/magento setup:di:compile

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
