### PR TITLE
Fixes issue where Design tab was unavilabe when managing "Select by Category" slider type.

### DIFF
--- a/Block/Adminhtml/Slider/Edit.php
+++ b/Block/Adminhtml/Slider/Edit.php
@@ -119,9 +119,9 @@ class Edit extends Container
             
             function showHideProductTab(){
                 if($('#slider_product_type').val() == 'custom'){
-                    $('#slider_tabs_products').parent().show();
+                    $('#slider_tabs_products').show();
                 } else {
-                    $('#slider_tabs_products').parent().hide();
+                    $('#slider_tabs_products').hide();
                 }
             }
         });


### PR DESCRIPTION

By using .parent() not only "Select Products" tab is hidden but all including Design tab which is applicable to all Slider types. Fixes issue where Design tab was unavilabe when managing "Select by Category" slider type.

![Screenshot_2020-11-07_at_12_04_39](https://user-images.githubusercontent.com/3989412/98439361-b45af880-20f1-11eb-94a5-d712d16b1175.png)

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/mageplaza/magento-2-product-slider/<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. 
2. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
